### PR TITLE
Add dependency so the "ssh" command is available.

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -73,6 +73,7 @@ Requires: python-setuptools
 %endif
 
 Requires: sshpass
+Requires: openssh-clients
 
 %description
 


### PR DESCRIPTION
I'm reasonably sure the package has been called "openssh-clients" across all distros since the RHEL5 era.
Installed Ansible on a "minimal" CentOS server and spent a bit of time having to figure out why everything was failing...
